### PR TITLE
Missing images when exporting project to Office on Windows if project folder is not C:\

### DIFF
--- a/static/defaults/Microsoft Word to Markdown.yaml
+++ b/static/defaults/Microsoft Word to Markdown.yaml
@@ -8,6 +8,7 @@ writer: markdown
 # Set to "all" to include everything.
 track-changes: accept
 # Extract images etc. from the document into this directory
+# Add resource-path
 extract-media: ./assets
 wrap: none
 # Set to setext to produce underlined h1 and h2


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
In version 1.8.9 of Zettlr, on Windows platforms, an error occurs when exporting items stored in folders, except C:\, as .docx or .odt. The image in the document will be lost as a result, this issue is not resolved yet.
I think it might be because of the path settings, it might be necessary to change some settings to make each file create the correct path to the subfolder with the correct images. Or maybe we need to make it correct by changing the image path to an absolute path.
## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The root cause of this problem may be that pandoc can only find images relative to the current working directory, not relative to where the .md containing the route is placed. So, we can try to use pandoc's --resource-path parameter to make pandoc point to the correct directory to solve this problem.
There is no defect in starting Pandoc from the command line with the following command, “E:\Drivers\Pandoc\Location” is the current path of the project directory：
E:\Drivers\Pandoc\Location op>pandoc "E:\Drivers\Pandoc\Location op\View-manager.en.md" -f markdown -t docx --toc-depth=2 -s --pdf-engine=xelatex --mathjax -o "E:\Drivers\Pandoc\Location op\view.docx"
However, if I launch it from any other folder, I need to adding the base folder of the project with pandoc's --resource-path parameter:
C:\Users\Dell>pandoc "e:\Drivers\Pandoc\Location op\View-manager.en.md" -f markdown -t docx --resource-path="e:\Drivers\Pandoc\Location op" --toc-depth=2 -s --pdf-engine=xelatex --mathjax -o "e:\Drivers\Pandoc\Location op\what2.docx"
## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Zettlr Version：Stable (most recent version)
Specify version：1.8.9 
Platform：Windows
Architecture：Intel 64bit
Operating System Version：Windows 10
